### PR TITLE
Watch for local deps changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ new Erik({
   ],
 
   /**
-   * Local dependencies to be bundled alongside your remote dependencies. Glob strings. Useful for
-   * including your bower-installed packages, for example.
+   * Local dependencies to be bundled alongside your remote dependencies. Glob strings.
    */
   localDependencies: [
     'public/build-lib.js',
-    'public/lib/ext/**/*'
+    'public/lib/ext/**/*',
+
+    // Include your specs here. Make sure that they are bundled as an IIFE.
+    'spec/client/tests.js',
   ],
 
   /**
@@ -84,11 +86,6 @@ new Erik({
     'https://cdn.jsdelivr.net/g/jquery@2.1.4',
     'https://cdn.jsdelivr.net/g/underscorejs@1.8.3',
   ],
-
-  /**
-   * Path to your bundled test suite. This should be an IIFE.
-   */
-  bundledSpecPath: 'spec/client/tests.js',
 
   /**
    * This configuration is not passed directly into Karma but rather is processed by Erik. Only

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ We welcome pull requests! Please lint your code using the JSHint configuration i
 
 ### Release history
 
+* 1.1.0 Re-run specs on any local dependency changes. Wrap `options.bundledSpecPath` into `options.localDependencies`, deprecating `options.bundledSpecPath`.
 * 1.0.3 Don't specify exact dependency versions.
 * 1.0.2 Add event-based watch example.
 * 1.0.1 Move dependencies to be non-dev dependencies.

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ class Erik {
     this._port = (options.karmaConfig && options.karmaConfig.port) || 9876;
     this._bundlePath = options.bundlePath || '';
 
-    this._assertValidOptions(options);
+    this._assertValidOptions();
 
     this._erikPath = path.join(options.bundlePath, '.erik');
 

--- a/index.js
+++ b/index.js
@@ -19,8 +19,7 @@ class Erik {
    * processing is done. Useful for registering your spec-building/processing tasks as dependencies
    * of Erik's testing task. These tasks will be run in serial as passed.
    * @param {String[]} [options.localDependencies] - Local dependencies to be bundled alongisde your
-   * remote dependencies. Glob strings. Useful for including your bower-installed packages, for
-   * example.
+   * remote dependencies. Glob strings.
    * @param {String[]} [options.remoteDependencies] - URLs corresponding to remote dependencies.
    * @param {Object} [options.karmaConfig]
    * @param {Number} [options.karmaConfig.port=9876] - Port on which to run the Karma server.

--- a/index.js
+++ b/index.js
@@ -160,11 +160,12 @@ class Erik {
     this._gulp.task('erik', (done) => {
       del.sync(this._erikPath);
 
-      const tasks = this._taskDependencies.concat([
+      const tasks = [
+        ...this._taskDependencies,
         'erik-fetch-remote-deps',
         'erik-run-spec',
         done
-      ]);
+      ];
 
       // Run everything serially.
       runSequence.use(this._gulp)(...tasks);


### PR DESCRIPTION
Deprecates `options.bundledSpecPath` and fixes https://github.com/mixmaxhq/erik/issues/2.