### PR TITLE
Add sourcemap support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "karma-jasmine": "^1.1.0",
     "karma-mocha-reporter": "^2.2.2",
     "karma-phantomjs-launcher": "^1.0.2",
+    "karma-sourcemap-loader": "^0.3.7",
     "run-sequence": "^1.2.2",
     "streamqueue": "^1.1.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,6 +1131,12 @@ karma@^1.7.0:
     tmp "0.0.31"
     useragent "^2.1.12"
 
+karma-sourcemap-loader@^0.3.7:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz#91322c77f8f13d46fed062b042e1009d4c4505d8"
+  dependencies:
+    graceful-fs "^4.1.2"
+
 kew@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/kew/-/kew-0.7.0.tgz#79d93d2d33363d6fdd2970b335d9141ad591d79b"


### PR DESCRIPTION
A fix for https://github.com/mixmaxhq/erik/issues/16.

Unfortunately when running tests in `watch` mode, I see "...WARN [reporter]: SourceMap position not
found for trace: undefined". I think this may be due to remote dependencies not having a sourcemap.
We could just ignore this warning, but it's annoying. Perhaps we could use `formatError` from
http://karma-runner.github.io/1.0/config/configuration-file.html to filter out the warning, but then
we run the risk of filtering out warnings caused by the user of erik not including sourcemaps.

The `sourcemap` `preprocessor` should probably be optional. We should probably add an option to Erik to specify whether it should be used.

This is turning out to be quite time-consuming, so I think I'll leave it for now and come back later.