### PR TITLE
Don't override Karma's default of failing on empty test suites

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,6 @@ class Erik {
         frameworks: ['jasmine'],
         browsers: this._browsers,
         reporters: ['mocha'],
-        failOnEmptyTestSuite: false,
 
         /**
          * Pass an empty object for `preprocessors` in order to disable Karma's default processing


### PR DESCRIPTION
Fixes https://github.com/mixmaxhq/erik/issues/19. More details there.